### PR TITLE
Rename include to include_tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,5 +4,5 @@
 - include_vars: "{{ ansible_os_family }}.yml"
   when: ansible_os_family == 'Debian'
 
-- include: "install-{{ ansible_distribution }}.yml"
+- include_tasks: "install-{{ ansible_distribution }}.yml"
   when: ansible_os_family == 'Debian'


### PR DESCRIPTION
`include` was remove sometime in 2023 from Ansible.